### PR TITLE
Add 'type' field in Feature to respect RFC7946

### DIFF
--- a/CodableGeoJSON/GeoJSON.swift
+++ b/CodableGeoJSON/GeoJSON.swift
@@ -18,6 +18,8 @@ public enum GeoJSON: Equatable {
         public let geometry: Geometry?
         /// Additional properties of the feature.
         public let properties: CodableJSON.JSON?
+        /// The type of the feature.
+        public let type: String
     }
 
     /// A list of `Feature` objects.


### PR DESCRIPTION
The Feature object needs a `type` field as per the Section 3.2 of RFC7946 (https://tools.ietf.org/html/rfc7946#section-3.2):

3.2 Feature Object

A Feature object represents a spatially bounded thing.  Every Feature
object is a GeoJSON object no matter where it occurs in a GeoJSON text.
  - A Feature object has a "type" member with the value "Feature".